### PR TITLE
Fix admin order access

### DIFF
--- a/app/Policies/OrdenPolicy.php
+++ b/app/Policies/OrdenPolicy.php
@@ -13,8 +13,7 @@ class OrdenPolicy
     public function viewAny(Usuario $usuario): bool
     {
         // Solo administradores y gerentes pueden ver el listado completo de órdenes
-        //return in_array($usuario->role, ['cliente', 'gerente']);
-        return $usuario->role !== 'administrador';
+        return in_array($usuario->role, ['administrador', 'gerente']);
     }
 
     /**

--- a/tests/Unit/OrdenPolicyTest.php
+++ b/tests/Unit/OrdenPolicyTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Usuario;
+use App\Policies\OrdenPolicy;
+use PHPUnit\Framework\TestCase;
+
+class OrdenPolicyTest extends TestCase
+{
+    public function test_admin_can_view_any_order()
+    {
+        $policy = new OrdenPolicy();
+        $admin = new Usuario(['role' => 'administrador']);
+
+        $this->assertTrue($policy->viewAny($admin));
+    }
+
+    public function test_client_cannot_view_any_order()
+    {
+        $policy = new OrdenPolicy();
+        $client = new Usuario(['role' => 'cliente']);
+
+        $this->assertFalse($policy->viewAny($client));
+    }
+}


### PR DESCRIPTION
## Summary
- adjust order view policy to allow admin access
- add unit test for OrdenPolicy

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68602b2444388321a0fa3eaaea381934